### PR TITLE
fix: using lsof command instead of storing the value in pid files

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,20 +126,13 @@ jobs:
             # 의존성 설치/업데이트
             uv sync
 
-            # 기존 프로세스 종료 (PID 파일 사용)
-            if [ -f uvicorn.pid ]; then
-              OLD_PID=$(cat uvicorn.pid)
-              if ps -p "$OLD_PID" >/dev/null 2>&1; then
-                kill "$OLD_PID" || true
-                sleep 3
-              fi
-              rm -f uvicorn.pid
-            fi
+            # 기존 프로세스 종료 
+            kill $(lsof -t -i :8000) || true
+            sleep 3
 
             # 새로 실행하고 PID 저장
             nohup uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 > ai.log 2>&1 &
-            echo $! > uvicorn.pid
-            echo "FastAPI restarted (PID: $(cat uvicorn.pid))"
+            echo "FastAPI restarted (PID: $!)"
 
       # ----------------------------
       # 7. Health Check
@@ -185,14 +178,8 @@ jobs:
             BACKUP_DIR="/home/ubuntu/ai_backup"
 
             # 현재 프로세스 종료
-            if [ -f "$TARGET_DIR/uvicorn.pid" ]; then
-              OLD_PID=$(cat "$TARGET_DIR/uvicorn.pid")
-              if ps -p "$OLD_PID" >/dev/null 2>&1; then
-                kill "$OLD_PID" || true
-                sleep 3
-              fi
-              rm -f "$TARGET_DIR/uvicorn.pid"
-            fi
+            kill $(lsof -t -i :8000) || true
+            sleep 3
 
             # 백업 복구
             if [ -d "$BACKUP_DIR" ]; then
@@ -215,8 +202,7 @@ jobs:
             uv sync
 
             nohup uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 > ai.log 2>&1 &
-            echo $! > uvicorn.pid
-            echo "FastAPI restarted after rollback (PID: $(cat uvicorn.pid))"
+            echo "FastAPI restarted after rollback (PID: $!)"
 
       # ----------------------------
       # 9. Discord 알림
@@ -347,18 +333,13 @@ jobs:
 
             uv sync
 
-            if [ -f uvicorn.pid ]; then
-              OLD_PID=$(cat uvicorn.pid)
-              if ps -p "$OLD_PID" >/dev/null 2>&1; then
-                kill "$OLD_PID" || true
-                sleep 3
-              fi
-              rm -f uvicorn.pid
-            fi
+            # 기존 프로세스 종료
+            kill $(lsof -t -i :8000) || true
+            sleep 3
 
+            # 새로 실행
             nohup uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 > ai.log 2>&1 &
-            echo $! > uvicorn.pid
-            echo "FastAPI restarted (PID: $(cat uvicorn.pid))"
+            echo "FastAPI restarted (PID: $!)"
 
       # ----------------------------
       # 7. Health Check
@@ -402,14 +383,9 @@ jobs:
             TARGET_DIR="/home/ubuntu/ai"
             BACKUP_DIR="/home/ubuntu/ai_backup"
 
-            if [ -f "$TARGET_DIR/uvicorn.pid" ]; then
-              OLD_PID=$(cat "$TARGET_DIR/uvicorn.pid")
-              if ps -p "$OLD_PID" >/dev/null 2>&1; then
-                kill "$OLD_PID" || true
-                sleep 3
-              fi
-              rm -f "$TARGET_DIR/uvicorn.pid"
-            fi
+            # 현재 프로세스 종료
+            kill $(lsof -t -i :8000) || true
+            sleep 3
 
             # 백업 복구
             if [ -d "$BACKUP_DIR" ]; then
@@ -432,8 +408,7 @@ jobs:
             uv sync
 
             nohup uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 > ai.log 2>&1 &
-            echo $! > uvicorn.pid
-            echo "FastAPI restarted after rollback (PID: $(cat uvicorn.pid))"
+            echo "FastAPI restarted after rollback (PID: $!)"
 
       # ----------------------------
       # 9. Discord 알림


### PR DESCRIPTION
## Summary
- [x] pid 파일 쓰는 부분 삭제 lsof 명령어 사용으로 대체

## 작업 내용 및 PR point
- pkill을 사용했을 때는 러너 쉘까지 죽이는 경우가 발생해 pid 파일을 사용하는 방식으로 수정한 바 있습니다.
- pid 파일에 값을 저장하는 데 있어 간헐적인 오류가 있다고 하셔서 lsof 명령어 사용으로 대체하는 수정 작업을 진행했습니다. 
- 랜덤하게 오류가 발생한 이유는 아직 파악하지 못했습니다. 
- `-t`는 terse mode로 필요한 값인 PID만 출력하기 위해 필요한 옵션입니다.
- `true`를 쓰지 않으면 종료시킬 프로세스가 없는 경우에 프로세스를 종료시키는 일을 에러로 간주해 cd가 중단된다고 하여 해당 값이 필요합니다.

## 테스트
- 머지 후 진행할 수 있으며 테스트를 거쳐야 결과물을 정확히 확인할 수 있을 것 같습니다. 